### PR TITLE
Fixes for compiling issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,16 @@ Only 8bit GRAY/RGB PNG images are handled.
 The code is written in ANSI C, and should compile on any system with
 an ANSI C compiler.
 
-The libpng header and libraries are required on the system for
-compilation and execution. On Linux, just use your package manager
-to install it:
+The following libraries are required on the system for compilation
+and execution:
+
+- libpng
+- libfftw3
+
+On Linux, you can install these using the following command:
+
 ```
-sudo apt-get install libpng
+sudo apt-get install libpng-dev libfftw3-dev build-essential
 ```
 
 For more information, see http://www.libpng.org/pub/png/libpng.html

--- a/src/Utilities/io_png.c
+++ b/src/Utilities/io_png.c
@@ -43,6 +43,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <assert.h>
+#include <string.h>
 
 /* option to use a local version of the libpng */
 #ifdef _LOCAL_LIBS


### PR DESCRIPTION
Hello Thierry,

First of all I just wanted to say thank you for your work and the related paper. It has been a great starting point for implementing deflicker. From the papers of Julie Delon and yourself, I have developed an understanding of midway equalisation and global deflicker so far, but the local deflicker maths is boggling my brain. 

Anyway this is a small PR that fixes problems I had when compiling this repo (Ubuntu 18.04 - missing dependencies and a missing include).